### PR TITLE
Post build failing tests as reviews so they can be resolved and collapsed

### DIFF
--- a/FunctionApp/Modules/GitHub/GitHub.psm1
+++ b/FunctionApp/Modules/GitHub/GitHub.psm1
@@ -12,6 +12,16 @@ function Get-GitHubPullRequest($PullRequestUrl) {
     }
 }
 
+function Get-GitHubPullRequestDiff($PullRequestDiffUrl) {
+    try {
+        Invoke-RestMethod -Uri $PullRequestDiffUrl -Headers $headers
+    }
+    catch {
+        $_ | Out-String | Write-Error
+        throw $_
+    }
+}
+
 function Get-GitHubPullRequestStatuses($PullRequestStatusesUrl, $Organization) {
     try {
         $statuses = Invoke-RestMethod -Uri $PullRequestStatusesUrl -Headers $headers
@@ -26,7 +36,7 @@ function Get-GitHubPullRequestStatuses($PullRequestStatusesUrl, $Organization) {
     }
 }
 
-function Send-GitHubComment($Url, $Body) {
+function Send-GitHubCommentOrReview($Url, $Body) {
     try {
         $null = Invoke-RestMethod -Headers $headers -Uri $url -Method Post -Body $Body
     }


### PR DESCRIPTION
PoshChan-Bot currently reports failing tests as PR comments, which usually take a lot spaces and cannot be collapsed, which makes it a little hard to review the actual comments for the PR.
It might be good if we post the failing tests as PR reviews, so once the tests are fixed, we can resolve the review comment and leave a clean view of other comments in the PR.

Note, for the file `FunctionApp/GitHub-Respond/run.ps1`, I changed the line ending from `CRLF` to `LF`.
https://github.com/SteveL-MSFT/PoshChan-Bot/pull/56/files?w=1 is handy to review the actual diffs.