### PR TITLE
Supply empty body to work around AzFunc issue

### DIFF
--- a/FunctionApp/PoshChan-Bot/run.ps1
+++ b/FunctionApp/PoshChan-Bot/run.ps1
@@ -47,6 +47,7 @@ function Get-FirstPullRequestFile($diff) {
 function Send-Ok {
     Push-OutputBinding -Name Response -Value ([HttpResponseContext]@{
         StatusCode = [HttpStatusCode]::OK
+        Body = ''
     })
 }
 


### PR DESCRIPTION
A regression was introduced in AzFunc that hasn't been fixed/deployed yet.  Workaround is to use an empty Body.